### PR TITLE
make sure that a valid language is passed

### DIFF
--- a/src/routes/llama/+server.js
+++ b/src/routes/llama/+server.js
@@ -12,10 +12,25 @@ let headers = {
 	'User-Agent': 'github-roast.pages.dev'
 };
 
+const validLanguages = [
+    'english',
+    'indonesian',
+    'indian',
+    'chinese',
+    'japanese',
+    'korean',
+    'france',
+    'vietnamese'
+];
+
 export async function POST({ request, platform }) {
 	let answerdebug = '';
 	const { username, language } = await request.json();
 
+	if (!validLanguages.includes(language)) {
+        	return json({ error: 'invalid language specified, please pass a valid language.' }, { status: 400 });
+    	}
+	
 	if (GITHUB_API_KEY) {
 		headers['Authorization'] = `token ${GITHUB_API_KEY}`;
 	}
@@ -123,6 +138,9 @@ export async function POST({ request, platform }) {
 		case 'vietnamese':
 			prompt = `Hãy đưa ra một lời châm chọc ngắn gọn và tàn nhẫn bằng tiếng lóng cho hồ sơ GitHub sau: ${username}. Đây là chi tiết: "${JSON.stringify(datas)}"`;
 			break;
+		default: // english and any other undefined languages
+		        prompt = `give a short and harsh roasting for the following github profile: ${username}. Here are the details: "${JSON.stringify(datas)}"`;
+		        break;
 	}
 
 	// answerdebug += prompt + '\n';


### PR DESCRIPTION
i noticed whenever i made a request to the llama endpoint with the following:

`{"username":"FokshaWasTaken","language":"english"}`

it always generated the same roast, however if i change the language to anything else, like "meow", it'll generate a new unique roast in English