### PR TITLE
Use Math.floor to get epoch seconds instead of parseInt

### DIFF
--- a/src/routes/llama/+server.js
+++ b/src/routes/llama/+server.js
@@ -185,7 +185,7 @@ export async function POST({ request, platform }) {
 				.bind(
 					username,
 					roast,
-					parseInt(new Date().getTime() / 1000),
+					Math.floor(new Date().getTime() / 1000),
 					request?.cf?.country || '',
 					sha256(request.headers.get('cf-connecting-ip')) || ''
 				)


### PR DESCRIPTION
`parseInt` is intended to be used for parsing strings containing integers. However, in the changed line, it was used to convert a float into an integer. This pull request replaces the call to `parseInt` with a call to `Math.floor` which is the correct function to use in this case.