### PR TITLE
feat(nix,ci): ci for automated test app, use flakes instead of raw mkshell

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,1 @@
-use nix
+use flake

--- a/.github/workflows/test-app.yml
+++ b/.github/workflows/test-app.yml
@@ -1,0 +1,30 @@
+name: Test the app 
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+       
+      - name: Install Nix package manager
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Setup Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Install dependencies
+        run: |
+          nix develop --command npm install
+
+      - name: Build the web-app
+        run: |
+          nix develop --command npm run build
+
+

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1722813957,
+        "narHash": "sha256-IAoYyYnED7P8zrBFMnmp7ydaJfwTnwcnqxUElC1I26Y=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "cb9a96f23c491c081b38eab96d22fa958043c9fa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -29,8 +29,8 @@
           '';
 
           env = {
-            OPENAI_API_KEY = H4nM7xP9LkS2VwQbR6cZpJ8D0oF5YtI3uN1lXgG;
-            GITHUB_API_KEY = Z8pQ1yE6CkR5XvA2jB9M0dW4L3sT7oNfH1U6rGx;
+            OPENAI_API_KEY = "H4nM7xP9LkS2VwQbR6cZpJ8D0oF5YtI3uN1lXgG";
+            GITHUB_API_KEY = "Z8pQ1yE6CkR5XvA2jB9M0dW4L3sT7oNfH1U6rGx";
 
           };
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-description = "Spicy GitHub Roast 🔥";
+  description = "Spicy GitHub Roast 🔥";
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
   };
@@ -29,8 +29,9 @@ description = "Spicy GitHub Roast 🔥";
           '';
 
           env = {
-                # In case u want
-                # foo = bar;
+            OPENAI_API_KEY = H4nM7xP9LkS2VwQbR6cZpJ8D0oF5YtI3uN1lXgG;
+            GITHUB_API_KEY = Z8pQ1yE6CkR5XvA2jB9M0dW4L3sT7oNfH1U6rGx;
+
           };
 
         };

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,39 @@
+{
+description = "Spicy GitHub Roast 🔥";
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    { nixpkgs, ... }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forAllSystems =
+        function: nixpkgs.lib.genAttrs systems (system: function (import nixpkgs { inherit system; }));
+    in
+    {
+      devShells = forAllSystems (pkgs: {
+        default = pkgs.mkShell {
+          packages = with pkgs; [
+            gh
+            nodejs_22
+          ];
+
+          shellHook = ''
+            echo "You are inside nix dev-shell"
+          '';
+
+          env = {
+                # In case u want
+                # foo = bar;
+          };
+
+        };
+      });
+    };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,0 @@
-{ pkgs ? import <nixpkgs> {} }: pkgs.mkShell {
-  nativeBuildInputs = [
-    pkgs.nodejs
-    pkgs.gh
-  ];
-}


### PR DESCRIPTION
Hi @codenoid ,

This pr does the followings,

1. Removing old raw `mkshell` in favor of `flakes` to exactly lock the dependencies.
2. Github ci to automatically test and build the app on push event on `main` branch.

AND: U ain't wrong tho 😭 

<img width="234" alt="Screenshot 2024-08-08 at 3 57 30 PM" src="https://github.com/user-attachments/assets/71178624-066b-45e5-8d99-17d2c12c2e37">

Let me know if you'd like to add/remove anything I'd be happy to follow u up. 

